### PR TITLE
Fixed plotting issue

### DIFF
--- a/Labs/Lab4-POMDP-MARL/MARL.ipynb
+++ b/Labs/Lab4-POMDP-MARL/MARL.ipynb
@@ -21,7 +21,7 @@
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "import random\n",
-    "from collections import defaultdict\n",
+    "from collections import defaultdict, OrderedDict\n",
     "import itertools\n",
     "import operator\n",
     "import time"
@@ -372,6 +372,7 @@
     "        plot_data[exp_name] = {\n",
     "            \"t\": [ts], \"captures\": [all_train_captures], \"table_size\": [all_table_sizes]\n",
     "        }\n",
+    "        grid_sizes.append(exp_name)\n",
     "    else:\n",
     "        plot_data[exp_name][\"t\"].append(ts)\n",
     "        plot_data[exp_name][\"captures\"].append(all_eval_captures)\n",


### PR DESCRIPTION
OrderedDict is now imported before use. grid_sizes is now used within the corresponding function. Plotting does not raise errors now (but it may need to be run twice to show correctly at least on your device). Hopefully this leads to the intended behaviour.